### PR TITLE
Version bump Vyxal to 2.18.3

### DIFF
--- a/web/front/js-json-extra/version.json
+++ b/web/front/js-json-extra/version.json
@@ -26,5 +26,5 @@
 	"raku":"Welcome to Rakudo v2022.06.0",
 	"ruby":"ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-musl]",
 	"rust":" 1.64.0",
-	"vyxal":"2.18.2",
+	"vyxal":"2.18.3",
 }


### PR DESCRIPTION
It'll be installed on the server next time the dockerfile is run because it's on PyPi