### PR TITLE
Fix bug with error positioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .env
 node_modules
 .vscode
-DS_Store
+.DS_Store

--- a/Client/src/pages/Problem.tsx
+++ b/Client/src/pages/Problem.tsx
@@ -419,7 +419,7 @@ const Problem: Component = () => {
                     input: rep.data.inputs[i],
                     expected: rep.data.expectedOutputs[i],
                     obtained: rep.data.outputs[i],
-                    error: rep.data.errors.length > i ? rep.data.errors[i] : "",
+                    error: rep.data.errors[i],
                 })
             }
 

--- a/Server/src/api/v1/routes/solutions.ts
+++ b/Server/src/api/v1/routes/solutions.ts
@@ -404,11 +404,8 @@ export const submitSolution = async (req: AuthenticatedRequest, res: Response): 
                 // Push the new data to ouput
                 outputs.push(data.out[i].trim().replace(/\s+\n/g, '\n'));
 
-
-
                 // Push the error to error
-                if (typeof data.err[i] === 'string' && data.err[i].length > 0) 
-                    errors.push(data.err[i]);
+                errors.push(data.err[i]);
 
                 // Push the success
                 successArray.push(data.out[i].trim().replace(/\s+\n/g, '\n') === expectedOutputs[i].trim());
@@ -420,8 +417,8 @@ export const submitSolution = async (req: AuthenticatedRequest, res: Response): 
             if (problemId === 26 && !challengeNewYearValid) {
                 success = false;
 
-                for (let error in errors) {
-                    error =`This challenge is a special challenge for the year 2023!
+                for (const idx in errors) {
+                    errors[idx] =`This challenge is a special challenge for the year 2023!
             Your code needs to have all the letters in "happynewyear2023" for it to work!
             Case and duplicate doesn't matters
             ----------------------------------------------------------------------------


### PR DESCRIPTION
There was a bug where errors were not aligned with each test case. Also, the error message with the Happy New Years one didn't work, because for one, for-in loops over the INDICES of an array, not the items (for-of loops over items), and even with for-of, it won't be overwritten by setting the variable. I fixed this.